### PR TITLE
Update config.xml to declare support for fingerprint sensor on power button PLUS fix brightness scale

### DIFF
--- a/rro_overlays/FrameworksResOverlayEvergo/res/values/config.xml
+++ b/rro_overlays/FrameworksResOverlayEvergo/res/values/config.xml
@@ -39,6 +39,8 @@
     <!-- Whether camera shutter sound is forced or not  (country specific). -->
      <bool name="config_camera_sound_forced">true</bool>
 
+     <bool name="config_is_powerbutton_fps">true</bool>
+     
     <!-- Flag specifying whether VoLTE should be available for carrier: independent of
          carrier provisioning. If false: hard disabled. If true: then depends on carrier
          provisioning, availability etc -->

--- a/rro_overlays/FrameworksResOverlayEvergo/res/values/config.xml
+++ b/rro_overlays/FrameworksResOverlayEvergo/res/values/config.xml
@@ -111,8 +111,8 @@
     <!-- Is the device capable of hot swapping an ICC Card -->
      <bool name="config_hotswapCapable">true</bool>
      
-    <!-- Does the device has a fps on power. -->
-     <bool name="config_fingerprintWakeAndUnlock">true</bool>
+    <!-- OFC the device has a fps on power. -->
+     <bool name="config_fingerprintWakeAndUnlock">false</bool>
 
     <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
      <bool name="config_intrusiveNotificationLed">true</bool>

--- a/rro_overlays/FrameworksResOverlayEvergo/res/values/config.xml
+++ b/rro_overlays/FrameworksResOverlayEvergo/res/values/config.xml
@@ -110,6 +110,9 @@
 
     <!-- Is the device capable of hot swapping an ICC Card -->
      <bool name="config_hotswapCapable">true</bool>
+     
+    <!-- Does the device has a fps on power. -->
+     <bool name="config_fingerprintWakeAndUnlock">true</bool>
 
     <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
      <bool name="config_intrusiveNotificationLed">true</bool>

--- a/rro_overlays/FrameworksResOverlayEvergo/res/values/config.xml
+++ b/rro_overlays/FrameworksResOverlayEvergo/res/values/config.xml
@@ -803,6 +803,18 @@
         <item>0:2:15</item>
     </string-array>
 
+    <!-- An array of arrays of side fingerprint sensor properties relative to each display.
+         Note: this value is temporary and is expected to be queried directly
+         from the HAL in the future. -->
+     <array name="config_sfps_sensor_props" translatable="false">
+        <item>@array/config_sfps_sensor_props_0</item>
+    </array>
+
+    <array name="config_sfps_sensor_props_0" translatable="false">
+@@ -516,4 +517,10 @@
+        <item>900</item> <!--item>sensorLocationY</item-->
+        <item>200</item> <!--item>sensorRadius</item-->
+    </array>
     <!-- Enables or disables fading edges when marquee is enabled in TextView.
          Off by default, since the framebuffer readback used to implement the
          fading edges is prohibitively expensive on most GPUs. -->

--- a/rro_overlays/FrameworksResOverlayEvergo/res/values/config.xml
+++ b/rro_overlays/FrameworksResOverlayEvergo/res/values/config.xml
@@ -112,7 +112,7 @@
      <bool name="config_hotswapCapable">true</bool>
      
     <!-- OFC the device has a fps on power. -->
-     <bool name="config_fingerprintWakeAndUnlock">false</bool>
+     <bool name="config_fingerprintWakeAndUnlock">true</bool>
 
     <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
      <bool name="config_intrusiveNotificationLed">true</bool>

--- a/rro_overlays/FrameworksResOverlayEvergo/res/values/config.xml
+++ b/rro_overlays/FrameworksResOverlayEvergo/res/values/config.xml
@@ -258,8 +258,8 @@
          when adapting to brighter or darker environments.  This parameter controls how quickly
          brightness changes occur in response to an observed change in light level that exceeds the
          hysteresis threshold. -->
-     <integer name="config_autoBrightnessBrighteningLightDebounce">4000</integer>
-     <integer name="config_autoBrightnessDarkeningLightDebounce">8000</integer>
+     <integer name="config_autoBrightnessBrighteningLightDebounce">100</integer>
+     <integer name="config_autoBrightnessDarkeningLightDebounce">100</integer>
 
     <!-- Light sensor event rate in milliseconds for automatic brightness control. -->
      <integer name="config_autoBrightnessLightSensorRate">250</integer>
@@ -405,201 +405,70 @@
          This array should have size one greater than the size of the config_autoBrightnessLevels
          array. The brightness values must be non-negative and non-decreasing. This must be
          overridden in platform specific overlays -->
-    <integer-array name="config_autoBrightnessDisplayValuesNits">
-        <item>3</item>
+
+    <array name="config_autoBrightnessLcdBacklightValues">
+        <item>2</item>
         <item>4</item>
-        <item>5</item>
-        <item>14</item>
+        <item>8</item>
+        <item>13</item>
+        <item>16</item>
         <item>21</item>
-        <item>27</item>
-        <item>35</item>
+        <item>29</item>
+        <item>37</item>
+        <item>39</item>
+        <item>44</item>
+        <item>47</item>
+        <item>49</item>
+        <item>50</item>
+        <item>50</item>
+        <item>50</item>
+        <item>50</item>
+        <item>51</item>
+        <item>51</item>
+        <item>51</item>
+        <item>51</item>
+        <item>51</item>
         <item>52</item>
+        <item>52</item>
+        <item>52</item>
+        <item>53</item>
+        <item>53</item>
+        <item>54</item>
+        <item>55</item>
+        <item>56</item>
+        <item>56</item>
+        <item>57</item>
+        <item>58</item>
+        <item>59</item>
+        <item>60</item>
+        <item>61</item>
+        <item>61</item>
+        <item>62</item>
+        <item>63</item>
+        <item>64</item>
+        <item>65</item>
+        <item>66</item>
+        <item>67</item>
+        <item>68</item>
         <item>69</item>
-        <item>84</item>
-        <item>93</item>
-        <item>93</item>
-        <item>94</item>
-        <item>94</item>
-        <item>95</item>
-        <item>96</item>
-        <item>96</item>
-        <item>96</item>
+        <item>70</item>
+        <item>75</item>
+        <item>82</item>
+        <item>90</item>
         <item>97</item>
-        <item>97</item>
-        <item>97</item>
-        <item>97</item>
-        <item>97</item>
-        <item>97</item>
-        <item>97</item>
-        <item>102</item>
-        <item>106</item>
-        <item>110</item>
         <item>112</item>
-        <item>114</item>
-        <item>116</item>
-        <item>118</item>
-        <item>119</item>
-        <item>122</item>
-        <item>123</item>
-        <item>125</item>
-        <item>128</item>
-        <item>130</item>
-        <item>131</item>
-        <item>134</item>
-        <item>136</item>
-        <item>137</item>
-        <item>140</item>
-        <item>142</item>
-        <item>144</item>
-        <item>169</item>
-        <item>196</item>
-        <item>222</item>
-        <item>248</item>
-        <item>270</item>
-        <item>300</item>
-        <item>320</item>
-        <item>335</item>
-        <item>400</item>
-        <item>417</item>
-        <item>433</item>
-        <item>450</item>
-        <item>520</item>
-    </integer-array>
-    <integer-array name="config_autoBrightnessLcdBacklightValues">
-        <item>31</item>
-        <item>31</item>
-        <item>31</item>
-        <item>31</item>
-        <item>111</item>
-        <item>144</item>
-        <item>175</item>
-        <item>245</item>
-        <item>302</item>
-        <item>348</item>
-        <item>382</item>
-        <item>404</item>
-        <item>406</item>
-        <item>407</item>
-        <item>408</item>
-        <item>409</item>
-        <item>412</item>
-        <item>414</item>
-        <item>416</item>
-        <item>417</item>
-        <item>419</item>
-        <item>420</item>
-        <item>423</item>
-        <item>426</item>
-        <item>428</item>
-        <item>432</item>
-        <item>442</item>
-        <item>449</item>
-        <item>456</item>
-        <item>458</item>
-        <item>466</item>
-        <item>472</item>
-        <item>479</item>
-        <item>486</item>
-        <item>494</item>
-        <item>500</item>
-        <item>507</item>
-        <item>516</item>
-        <item>522</item>
-        <item>530</item>
-        <item>536</item>
-        <item>545</item>
-        <item>550</item>
-        <item>559</item>
-        <item>565</item>
-        <item>674</item>
-        <item>783</item>
-        <item>905</item>
-        <item>1028</item>
-        <item>1152</item>
-        <item>1284</item>
-        <item>1418</item>
-        <item>1600</item>
-        <item>1760</item>
-        <item>1900</item>
-        <item>2000</item>
-        <item>2047</item>
-        <item>2047</item>
-    </integer-array>
-    <!-- An array of floats describing the screen brightness in nits corresponding to the backlight
-         values in the config_screenBrightnessBacklight array.  On OLED displays these  values
-         should be measured with an all white image while the display is in the fully on state.
-         Note that this value should *not* reflect the maximum brightness value for any high
-         brightness modes but only the maximum brightness value obtainable in a sustainable manner.
-         This array should be equal in size to config_screenBrightnessBacklight -->
-    <array name="config_screenBrightnessNits">
-        <item>2.0482</item>
-        <item>2.7841</item>
-        <item>3.79505</item>
-        <item>4.4748</item>
-        <item>5.08</item>
-        <item>6.4233</item>
-        <item>8.0848</item>
-        <item>11.6607</item>
-        <item>13.2347</item>
-        <item>15.0676</item>
-        <item>16.8302</item>
-        <item>18.4261</item>
-        <item>20.3103</item>
-        <item>21.9042</item>
-        <item>23.5456</item>
-        <item>25.2137</item>
-        <item>27.1769</item>
-        <item>28.9571</item>
-        <item>30.5244</item>
-        <item>32.3535</item>
-        <item>34.0867</item>
-        <item>42.366</item>
-        <item>51.1309</item>
-        <item>59.52</item>
-        <item>67.744</item>
-        <item>75.9738</item>
-        <item>84.6332</item>
-        <item>94.1525</item>
-        <item>102.2207</item>
-        <item>110.4878</item>
-        <item>117.0405</item>
-        <item>124.3733</item>
-        <item>130.9928</item>
-        <item>140.4247</item>
-        <item>149.3156</item>
-        <item>157.1995</item>
-        <item>165.3651</item>
-        <item>173.2726</item>
-        <item>181.4272</item>
-        <item>189.1402</item>
-        <item>197.5334</item>
-        <item>205.6301</item>
-        <item>213.9381</item>
-        <item>222.2769</item>
-        <item>230.0891</item>
-        <item>238.6084</item>
-        <item>246.5399</item>
-        <item>255.6544</item>
-        <item>263.6221</item>
-        <item>271.9324</item>
-        <item>279.1449</item>
-        <item>288.5736</item>
-        <item>297.6628</item>
-        <item>306.1899</item>
-        <item>314.4511</item>
-        <item>322.1404</item>
-        <item>330.969</item>
-        <item>338.2251</item>
-        <item>346.2251</item>
-        <item>354.567</item>
-        <item>370.799</item>
-        <item>413.1738</item>
-        <item>415.6397</item>
-        <item>417.264</item>
-        <item>419.264</item>
-        <item>421.264</item>
-        <item>424.646</item>
-        <item>427.6287</item>
+        <item>127</item>
+        <item>143</item>
+        <item>159</item>
+        <item>176</item>
+        <item>198</item>
+        <item>219</item>
+        <item>236</item>
+        <item>249</item>
+        <item>251</item>
+        <item>252</item>
+        <item>254</item>
+        <item>255</item>
     </array>
 
     <!-- An array describing the screen's backlight values corresponding to the brightness
@@ -813,7 +682,7 @@
          the screen brightness is recalculated. See the config_ambientThresholdLevels
          description for how the constraint value is chosen. -->
     <integer-array name="config_ambientBrighteningThresholds">
-        <item>5</item>
+        <item>2</item>
         <item>5</item>
         <item>10</item>
         <item>30</item>

--- a/rro_overlays/SettingsOverlayEvergo/res/values/config.xml
+++ b/rro_overlays/SettingsOverlayEvergo/res/values/config.xml
@@ -27,8 +27,7 @@
          2 = left side
          3 = right side
     -->
-    <integer name="config_fingerprintSensorLocation">3</integer>
-
+    <!-- Sadly no more config_fingerprintSensorLocation -->
     <!-- Whether or not the device is capable of multiple levels of vibration intensity.
          Note that this is different from whether it can control the vibration amplitude as some
          devices will be able to vary their amplitude but do not possess enough dynamic range to


### PR DESCRIPTION
From ArrowOS's [commit:](https://github.com/ArrowOS/android_packages_apps_Settings/commit/2ccbcc6477b1a1ce37797ebeba29cf881ce227b6)
@Override
    public boolean isAvailable() {
        // Enable it for just powerbutton fps devices
        // Disable for devices config_fingerprintWakeAndUnlock set to false.
        return getFingerprintSettings() != 2 && mContext.getResources().getBoolean(
                com.android.internal.R.bool.config_is_powerbutton_fps);
    }