### PR TITLE
 Add lineage fastcharge

### DIFF
--- a/configs/props/vendor.prop
+++ b/configs/props/vendor.prop
@@ -70,6 +70,7 @@ persist.vendor.radio.mtk_dsbp_support=2
 persist.vendor.radio.mtk_ps2_rat=N/L/W/G
 persist.vendor.radio.mtk_ps3_rat=G
 persist.vendor.radio.smart.data.switch=1
+persist.vendor.fastchg_enabled=1
 persist.vendor.vilte_support=1
 persist.vendor.viwifi_support=1
 persist.vendor.vonr_setting_support=1

--- a/device.mk
+++ b/device.mk
@@ -97,6 +97,10 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PACKAGES += \
     android.hardware.ir@1.0-service.xiaomi
 
+# Fastcharge
+PRODUCT_PACKAGES += \
+    vendor.lineage.fastcharge@1.0-service.evergo
+
 # Bluetooth
 PRODUCT_PACKAGES += \
     audio.bluetooth.default \
@@ -381,6 +385,7 @@ PRODUCT_PACKAGES += \
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/rootdir/etc/fstab.emmc:$(TARGET_COPY_OUT_RECOVERY)/root/first_stage_ramdisk/fstab.emmc \
     $(LOCAL_PATH)/rootdir/etc/fstab.mt6833:$(TARGET_COPY_OUT_RECOVERY)/root/first_stage_ramdisk/fstab.mt6833
+
 
 # RenderScript
 PRODUCT_PACKAGES += \

--- a/fastcharge/Android.bp
+++ b/fastcharge/Android.bp
@@ -1,0 +1,37 @@
+//
+// Copyright (C) 2020-2021 The LineageOS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+cc_binary {
+    name: "vendor.lineage.fastcharge@1.0-service.evergo",
+    init_rc: ["vendor.lineage.fastcharge@1.0-service.evergo.rc"],
+    defaults: ["hidl_defaults"],
+    relative_install_path: "hw",
+    proprietary: true,
+    local_include_dirs: ["include"],
+    srcs: [
+        "FastCharge.cpp",
+        "service.cpp",
+    ],
+    shared_libs: [
+        "libbase",
+        "libbinder",
+        "libcutils",
+        "libhidlbase",
+        "libutils",
+        "vendor.lineage.fastcharge@1.0",
+    ],
+    vintf_fragments: ["vendor.lineage.fastcharge@1.0-service.evergo.xml"],
+}

--- a/fastcharge/FastCharge.cpp
+++ b/fastcharge/FastCharge.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2020-2021 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "fastcharge@1.0-service.evergo"
+
+#include "FastCharge.h"
+#include <android-base/logging.h>
+#include <cutils/properties.h>
+
+#include <fstream>
+#include <iostream>
+#include "xiaomi_fastcharge.h"
+
+namespace vendor {
+namespace lineage {
+namespace fastcharge {
+namespace V1_0 {
+namespace implementation {
+
+static constexpr const char* kFastChargingProp = "persist.vendor.fastchg_enabled";
+
+/*
+ * Write value to path and close file.
+ */
+template <typename T>
+static void set(const std::string& path, const T& value) {
+    std::ofstream file(path);
+
+    if (!file) {
+        PLOG(ERROR) << "Failed to open: " << path;
+        return;
+    }
+
+    LOG(DEBUG) << "write: " << path << " value: " << value;
+
+    file << value << std::endl;
+
+    if (!file) {
+        PLOG(ERROR) << "Failed to write: " << path << " value: " << value;
+    }
+}
+
+template <typename T>
+static T get(const std::string& path, const T& def) {
+    std::ifstream file(path);
+
+    if (!file) {
+        PLOG(ERROR) << "Failed to open: " << path;
+        return def;
+    }
+
+    T result;
+
+    file >> result;
+
+    if (file.fail()) {
+        PLOG(ERROR) << "Failed to read: " << path;
+        return def;
+    } else {
+        LOG(DEBUG) << "read: " << path << " value: " << result;
+        return result;
+    }
+}
+
+FastCharge::FastCharge() {
+    setEnabled(property_get_bool(kFastChargingProp, FASTCHARGE_DEFAULT_SETTING));
+}
+
+Return<bool> FastCharge::isEnabled() {
+    return get(FASTCHARGE_PATH, 0) > 0;
+}
+
+Return<bool> FastCharge::setEnabled(bool enable) {
+    set(FASTCHARGE_PATH, enable ? 1 : 0);
+
+    bool enabled = isEnabled();
+    property_set(kFastChargingProp, enabled ? "1" : "0");
+
+    return enabled;
+}
+
+}  // namespace implementation
+}  // namespace V1_0
+}  // namespace fastcharge
+}  // namespace lineage
+}  // namespace vendor

--- a/fastcharge/FastCharge.h
+++ b/fastcharge/FastCharge.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020-2022 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <hidl/MQDescriptor.h>
+#include <hidl/Status.h>
+#include <vendor/lineage/fastcharge/1.0/IFastCharge.h>
+
+namespace vendor {
+namespace lineage {
+namespace fastcharge {
+namespace V1_0 {
+namespace implementation {
+
+using ::android::sp;
+using ::android::hardware::hidl_array;
+using ::android::hardware::hidl_memory;
+using ::android::hardware::hidl_string;
+using ::android::hardware::hidl_vec;
+using ::android::hardware::Return;
+using ::android::hardware::Void;
+
+using ::vendor::lineage::fastcharge::V1_0::IFastCharge;
+
+
+struct FastCharge : public IFastCharge {
+    FastCharge();
+
+    Return<bool> isEnabled() override;
+    Return<bool> setEnabled(bool enable) override;
+};
+
+}  // namespace implementation
+}  // namespace V1_0
+}  // namespace fastcharge
+}  // namespace lineage
+}  // namespace vendor

--- a/fastcharge/include/xiaomi_fastcharge.h
+++ b/fastcharge/include/xiaomi_fastcharge.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2020-2022 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#define FASTCHARGE_DEFAULT_SETTING true
+#define FASTCHARGE_PATH "/sys/class/power_supply/pd_active"

--- a/fastcharge/service.cpp
+++ b/fastcharge/service.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "fastcharge@1.0-service.evergo"
+
+#include <android-base/logging.h>
+#include <hidl/HidlTransportSupport.h>
+
+#include "FastCharge.h"
+
+using android::hardware::configureRpcThreadpool;
+using android::hardware::joinRpcThreadpool;
+
+using vendor::lineage::fastcharge::V1_0::IFastCharge;
+using vendor::lineage::fastcharge::V1_0::implementation::FastCharge;
+
+using android::OK;
+using android::status_t;
+
+int main() {
+    android::sp<FastCharge> service = new FastCharge();
+
+    configureRpcThreadpool(1, true);
+
+    status_t status = service->registerAsService();
+    if (status != OK) {
+        LOG(ERROR) << "Cannot register FastCharge HAL service.";
+        return 1;
+    }
+
+    LOG(INFO) << "FastCharge HAL service ready.";
+
+    joinRpcThreadpool();
+
+    LOG(ERROR) << "FastCharge HAL service failed to join thread pool.";
+    return 1;
+}

--- a/fastcharge/vendor.lineage.fastcharge@1.0-service.evergo.rc
+++ b/fastcharge/vendor.lineage.fastcharge@1.0-service.evergo.rc
@@ -1,0 +1,11 @@
+on init
+    chown system system /sys/class/power_supply/pd_active
+
+service vendor.fastcharge-hal-1-0 /vendor/bin/hw/vendor.lineage.fastcharge@1.0-service.evergo
+    class hal
+    user system
+    group system
+    disabled
+
+on property:sys.boot_completed=1
+    start vendor.fastcharge-hal-1-0

--- a/fastcharge/vendor.lineage.fastcharge@1.0-service.evergo.xml
+++ b/fastcharge/vendor.lineage.fastcharge@1.0-service.evergo.xml
@@ -1,0 +1,11 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>vendor.lineage.fastcharge</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IFastCharge</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>

--- a/rootdir/etc/init.mt6833.rc
+++ b/rootdir/etc/init.mt6833.rc
@@ -10,7 +10,7 @@ import /vendor/etc/init/hw/init.mal.rc
 import /vendor/etc/init/hw/init.sensor_2_0.rc
 import /vendor/etc/init/hw/init.stnfc.rc
 import /system/etc/init/hw/init.stnfc.rc
-
+import /vendor/etc/init/hw/init.batterysecret.rc
 # init.modem.rc must be the LAST rc file because vold.post_fs_data_done is set in it
 import /vendor/etc/init/hw/init.modem.rc
 # *** DO NOT import the new rc file after this line ***

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -1,0 +1,2 @@
+# Fastcharge
+/vendor/bin/hw/vendor\.lineage\.fastcharge@1\.0-service\.evergo                u:object_r:hal_lineage_fastcharge_default_exec:s0

--- a/sepolicy/vendor/property.te
+++ b/sepolicy/vendor/property.te
@@ -1,0 +1,2 @@
+vendor_internal_prop(vendor_fastcharge_prop);
+

--- a/sepolicy/vendor/property_contexts
+++ b/sepolicy/vendor/property_contexts
@@ -1,0 +1,2 @@
+# Fastcharge
+persist.vendor.fastchg_enabled              u:object_r:vendor_fastcharge_prop:s0

--- a/vintf/framework_compatibility_matrix.xml
+++ b/vintf/framework_compatibility_matrix.xml
@@ -163,6 +163,14 @@
             <instance>default</instance>
         </interface>
     </hal>
+    <hal format="hidl">
+        <name>vendor.lineage.fastcharge</name>
+        <version>1.0</version>
+        <interface>
+            <name>IFastCharge</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
     <hal format="hidl" optional="true">
         <name>android.hardware.wifi</name>
         <version>1.0-5</version>


### PR DESCRIPTION

Add lineage fastcharge

Tho i dont know if sam stuff will work on mtk
fastcharge: Convert to blueprint


Update fastcharge src to adapt to evergo

Update fastcharge src to adapt to evergo


Build fastcharge hal


update fcm

not firebase cloud messaging
Update vendor.lineage.fastcharge@1.0-service.evergo.rc
update fastcharge path

Switch to vendor battsec
Drop battsec and use vendor one.


Add fastcharge prop


Redo fc prop


Rearrange fc blobs and props


Remove unused prop

