### PR TITLE
Correct fastcharge path

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -53,5 +53,5 @@
         <item>115</item> <!--item>sensorRadius</item-->
     </array>
     <!-- Path to fast charging status file to detect whether an oem fast charger is active -->
-    <string name="config_oemFastChargerStatusPath" translatable="false">/sys/class/power_supply/pd_active</string>
+    <string name="config_oemFastChargerStatusPath" translatable="false">/sys/class/power_supply/usb/pd_active</string>
 </resources>


### PR DESCRIPTION
This ig will not fix the low charge current issue but only let the system know it IS connected to a oem charger.
I guess we need to change drivers for 33w to work.